### PR TITLE
Complete rewrite that works without rewriting

### DIFF
--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -152,4 +152,13 @@ suite "with":
         check fn(1) == 3
       check fn(1) == 2
 
+  test "visible through template":
+    template t1(): untyped =
+      field1
+    var foo = (field1: 100, field2: "something")
+    with foo:
+      check t1() == 100
+      check field1 == 100
+      check field2 == "something"
+
 


### PR DESCRIPTION
This approach simply creates templates for each of the fields in the
object or tuple that was passed and gives Nim the task of expanding them
to the right thing. This means that templates called from within a with
section can also use the fields of the object directly, and can fix some
bugs where ambiguity of the symbols would make things hard to rewrite
the body correctly.